### PR TITLE
Bug Fix: Unconnected containers not showing as options for connect to a network

### DIFF
--- a/server/routes/containersRouter.ts
+++ b/server/routes/containersRouter.ts
@@ -3,6 +3,14 @@ import containersController from '../controllers/containersController';
 import networksController from '../controllers/networksController';
 const router = express.Router();
 
+router.get(
+  '/',
+  containersController.getRunningContainers,
+  (req: Request, res: Response) => {
+    res.status(200).json(res.locals.containers);
+  }
+);
+
 // disconnect container from network
 // return new array of fresh networks/containers
 router.delete(

--- a/src/components/MainDisplay.tsx
+++ b/src/components/MainDisplay.tsx
@@ -64,7 +64,6 @@ export const MainDisplay: React.FC<IProps> = ({ networks, setNetworks }) => {
           networkName={networkName}
           toggleConnectContainerModal={toggleConnectContainerModal}
           containers={containers}
-          networks={networks}
           setNetworks={setNetworks}
         />
       ) : null}


### PR DESCRIPTION
- Reintegrated backend route for getting list of all running containers
- Added fetch in the ConnectContainerModal to get this list of containers
- This list will include containers that are running but not connected to a network
- This fixed a bug which causes only containers that had a network connection already to appear in the list of options