### PR TITLE
Error modal fix

### DIFF
--- a/server/controllers/networksController.ts
+++ b/server/controllers/networksController.ts
@@ -6,9 +6,6 @@ import { formatNetworksAndContainers } from '../helpers/formatNetworksAndContain
 // make the terminal commands return normal thenable promises
 const exec = util.promisify(child_process.exec);
 
-// const somethingController = {}
-// somethingController.doSomethong = function
-
 // JS Module pattern:
 const networksController = (() => {
   const getNetworksAndContainers = async (
@@ -51,8 +48,6 @@ const networksController = (() => {
     res: Response,
     next: NextFunction
   ) => {
-    // name of network and associated driver
-
     try {
       const { networkName, driver } = req.body;
       // only checking for error as we don't need

--- a/server/routes/containersRouter.ts
+++ b/server/routes/containersRouter.ts
@@ -18,7 +18,6 @@ router.delete(
   containersController.disconnectContainer,
   networksController.getNetworksAndContainers,
   (req: Request, res: Response) => {
-    console.log('hello from delete to continaers');
     res.status(200).json(res.locals.networksAndContainers);
   }
 );

--- a/server/server.ts
+++ b/server/server.ts
@@ -35,7 +35,6 @@ app.get('*', (req: Request, res: Response) => {
 
 // global error handler
 const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
-  console.log('global error handler', err);
   const defaultErr = {
     log: 'unknown middleware error',
     status: 400,

--- a/src/components/DockerUnresponsive.tsx
+++ b/src/components/DockerUnresponsive.tsx
@@ -1,0 +1,14 @@
+import { LoadingSpinner } from '../utils/LoadingSpinner';
+import './modal.scss';
+
+export const DockerUnresponsive = () => {
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <LoadingSpinner />
+        Unable to connect with Docker. Please make sure the Docker daemon is
+        running.
+      </div>
+    </div>
+  );
+};

--- a/src/components/ErrorModal.tsx
+++ b/src/components/ErrorModal.tsx
@@ -11,14 +11,7 @@ export const ErrorModal: React.FC<IProps> = ({
   setErrorModalDisplay,
 }) => {
   let errorModalContent;
-  if (error === 'docker-unresponsive') {
-    errorModalContent = (
-      <>
-        Unable to connect to the Docker daemon. Please make sure Docker is
-        running.
-      </>
-    );
-  } else if (error === 'connect-container-error') {
+  if (error === 'connect-container-error') {
     errorModalContent = (
       <>
         Error connecting container. Please try again.

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -7,6 +7,7 @@ import { Home } from './Home';
 import { Header } from './Header';
 import { DeleteNetworkModal } from './DeleteNetworkModal';
 import { ErrorModal } from './ErrorModal';
+import { DockerUnresponsive } from './DockerUnresponsive';
 
 // array of network objects
 interface IState {
@@ -22,6 +23,8 @@ export const MainContainer = () => {
   const [deleteNetworkModalDisplay, setDeleteNetworkModalDislay] =
     useState<boolean>(false);
   const [errorModalDisplay, setErrorModalDisplay] = useState<string>('');
+  const [dockerUnresponsiveModalDisplay, setDockerUnresponsiveModalDisplay] =
+    useState<boolean>(false);
   const [networkToDelete, setNetworkToDelete] = useState<string>('');
   const [sideNavDisplay, setSideNavDisplay] = useState<boolean>(true);
 
@@ -39,15 +42,11 @@ export const MainContainer = () => {
         return res.json();
       })
       .then((networks) => {
-        // Keep error modal open if error does not originate
-        // from this fetch
-        if (errorModalDisplay === 'docker-unresponsive') {
-          setErrorModalDisplay('');
-        }
+        setDockerUnresponsiveModalDisplay(false);
         setNetworks(networks);
       })
       .catch(() => {
-        setErrorModalDisplay('docker-unresponsive');
+        setDockerUnresponsiveModalDisplay(true);
       });
   };
 
@@ -110,6 +109,7 @@ export const MainContainer = () => {
             error={errorModalDisplay}
           />
         ) : null}
+        {dockerUnresponsiveModalDisplay ? <DockerUnresponsive /> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
Placed the error message regarding a failure to connect to docker in its own modal. 
- This fixed a bug causing modals unconnected to our regular docker polling to be opened/closed in unexpected ways. 