### PR TITLE
Cookie cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.env

--- a/src/components/ListDisplay.tsx
+++ b/src/components/ListDisplay.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import './listDisplay.scss';
 
 interface IProps {
@@ -45,7 +46,7 @@ export const ListDisplay: React.FC<IProps> = ({
 
   const containerList = containers.map((container) => {
     return (
-      <>
+      <React.Fragment key={container.id}>
         <div className="container-list-item">{`${container.name}`}</div>
         <div className="container-list-item">{`${container.id}`}</div>
         <div className="container-list-item">{`${container.ipAddress}`}</div>
@@ -54,7 +55,7 @@ export const ListDisplay: React.FC<IProps> = ({
         >
           Disconnect
         </button>
-      </>
+      </React.Fragment>
     );
   });
 

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -41,6 +41,24 @@ export const MainContainer = () => {
     setSideNavDisplay(!sideNavDisplay);
   };
 
+  const getCache = (name: string) => {
+    const result = document.cookie.match(
+      '(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)'
+    );
+    return result ? result.pop() : '';
+  };
+
+  const deleteCache = (name: string, path: string, domain: string) => {
+    if (getCache(name)) {
+      document.cookie =
+        name +
+        '=' +
+        (path ? ';path=' + path : '') +
+        (domain ? ';domain=' + domain : '') +
+        ';expires=Thu, 01 Jan 1970 00:00:01 GMT';
+    }
+  };
+
   const getNetworks = () => {
     fetch('/api/networks')
       .then((res) => {
@@ -52,7 +70,14 @@ export const MainContainer = () => {
       })
       .then((networks) => {
         setDockerUnresponsiveModalDisplay(false);
-        setNetworks(networks);
+        // cache network data in cookie
+        // only re-render when data is fresh
+
+        const networkCache = JSON.stringify(networks);
+        if (networkCache !== getCache('networkCache')) {
+          document.cookie = 'networkCache=' + networkCache;
+          setNetworks(networks);
+        }
       })
       .catch(() => {
         // Open error modal if docker unresponsive
@@ -69,11 +94,14 @@ export const MainContainer = () => {
   };
 
   useEffect(() => {
+    // delete cache if it exists on mount
+    deleteCache('networkCache', '/', 'localhost');
+    deleteCache('networkCache', '/networks', 'localhost');
     getNetworks();
     // Poll docker for updates to networks/containers
     window.setInterval(() => {
       getNetworks();
-    }, 10000);
+    }, 3000);
   }, []);
 
   return (

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -72,7 +72,6 @@ export const MainContainer = () => {
         setDockerUnresponsiveModalDisplay(false);
         // cache network data in cookie
         // only re-render when data is fresh
-
         const networkCache = JSON.stringify(networks);
         if (networkCache !== getCache('networkCache')) {
           document.cookie = 'networkCache=' + networkCache;


### PR DESCRIPTION
- employed cache strategy to eliminate frontend re-renders
- caching network data in a browser cookie
- every time docker is queried for new data, the new data is compared against the cache, and if there is a difference, the cache is updated and we set state